### PR TITLE
Update package.json license reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,5 @@
     "type": "git",
     "url": "git@github.com:vuejs/vue-html-loader.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Scheme has changed. For example: running `npm view vue-html-loader license` in terminal returns `undefined` instead of `MIT`.
See the docs for further information: https://docs.npmjs.com/files/package.json#license
